### PR TITLE
Fix a bug in SKView

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -100,7 +100,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   StarterKit:
-    :path: .
+    :path: "."
 
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67

--- a/StarterKit/Classes/UI/Views/SKView.m
+++ b/StarterKit/Classes/UI/Views/SKView.m
@@ -11,13 +11,6 @@
 
 @implementation SKView
 
-- (instancetype)init {
-  if (self = [super init]) {
-    [self setupViews];
-  }
-  return self;
-}
-
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
         [self setupViews];


### PR DESCRIPTION
`-init` will cause `-setupViews` be called twice.
